### PR TITLE
:bug: fix decimal position

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -131,8 +131,8 @@ export async function joinImages(
 
       return {
         input: buffer,
-        left: px + left,
-        top: py + top,
+        left: Math.floor(px + left),
+        top: Math.floor(py + top),
       };
     },
   );


### PR DESCRIPTION
decimal position would cause sharp lib to throw error.
reproduction code:
```javascript
const joinImages = require('join-images').default

const buffer3x1 = Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAMAAAABCAQAAACx6dw/AAAADUlEQVR42mNk+M8ABAAFCQEBRpvUyAAAAABJRU5ErkJggg==', 'base64')
const buffer2x1 = Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAIAAAABCAQAAABeK7cBAAAADUlEQVR42mNk+M/AAAADBwEBPuJ7gwAAAABJRU5ErkJggg==', 'base64')
joinImages([buffer3x1, buffer2x1], { align: 'center' })
```